### PR TITLE
Do not report config errors on startup

### DIFF
--- a/anki_wallpaper/__init__.py
+++ b/anki_wallpaper/__init__.py
@@ -213,7 +213,7 @@ def setup_next_wallpaper_menu():
 
 
 config = Config()
-config.load()
+config.load(report_errors=False)
 
 
 @run_on_configuration_change

--- a/anki_wallpaper/configuration.py
+++ b/anki_wallpaper/configuration.py
@@ -197,7 +197,7 @@ class Config:
         self.wallpapers = Wallpapers([], [], [])
         self.indexes = Indexes(0, 0)
 
-    def load(self):
+    def load(self, report_errors: bool = True):
         data = read_config()
 
         if data[FOLDER_WITH_WALLPAPERS] == "change_me":
@@ -208,7 +208,7 @@ class Config:
         self.wallpapers = Wallpapers.from_data(data)
         self.indexes = Indexes.from_data(data)
 
-        if self.wallpapers.errors:
+        if report_errors and self.wallpapers.errors:
             show_warning_about_wallpaper_folder_config_errors(self.wallpapers.errors)
 
     def next_wallpaper(self):


### PR DESCRIPTION
Some errors like the ones about missing light/dark wallpapers can be annoying to see each time for people who only use one mode.
This PR makes the add-on ignore config errors on startup. This will mask more serious errors like a non-existing wallpaper folder, but I think the warning on config save is enough.

Of course, one can always put a dummy file in the folder to silence the errors, so feel free to close this if you think it's better to always report errors.